### PR TITLE
fix difference highlight code between production and dev server

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,0 +1,1 @@
+require("prismjs/themes/prism-solarizedlight.css");

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,4 @@
 import React from "react"
-require("prismjs/themes/prism-solarizedlight.css");
 
 export default function Home() {
   return <div>Hello world!</div>


### PR DESCRIPTION
When running `gatsby develop` the CSS was applied correctly but not when running `gatsby build` (used by Gatsby Cloud). 
Moving requiring the css to `gatsby-browser.js` turned out to be [the solution](https://stackoverflow.com/a/56509444).
I understand it has something to do with how Gatsby builds but don't know what exactly went wrong before.